### PR TITLE
Comment out gatsby-plugin-offline

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -95,7 +95,7 @@ module.exports = {
     },
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.app/offline
-    "gatsby-plugin-offline",
+    // "gatsby-plugin-offline",
     {
       resolve: `gatsby-plugin-favicon`,
       options: {


### PR DESCRIPTION
- Troubleshooting ssl padlock not being able to click to view certs